### PR TITLE
throw errors from distance2curve and constrain s

### DIFF
--- a/xy2sn.m
+++ b/xy2sn.m
@@ -127,11 +127,15 @@ catch err
         error('MATLAB:xy2sn:distance2curveunpatched', ['There is a bug in the distance2curve function.\n'...
             'Please open the function file using "edit distance2curve.m"\n'...
             'and edit line 453 to read\n  if nargout == 3\ninstead of\n  if nargout > 3']);
+    else
+        rethrow(err)
     end
 end
 
 PX = P(:,1);
 PY = P(:,2);
+
+s = min(max(s,0),1);
 
 % Calculate tangential vectors on thalweg curve
 if splinesampling > 0


### PR DESCRIPTION
Two small tweaks:

1.  Original try/catch around distance2curve blocked error handling except in one expected case, but other errors (usually as a result of unexpected or badly-formatted user input) could block successful calculation in xy2sn and lead to uninformative errors because P, n, and s weren't assigned.  I added a rethrow to catch these.

2. In cases of x/y points very close to the centerline end points, s values returned by distance2curve can be just barely (machine precision-ish) outside the 0-1 range, which leads to an interparc error.  I added an explicit constraint to keep these values in range. 